### PR TITLE
Add icon for karate/drupal-dev

### DIFF
--- a/_data/projects/drupal-dev.yml
+++ b/_data/projects/drupal-dev.yml
@@ -3,7 +3,7 @@ year_created: 2022
 source: https://github.com/karate/drupal-dev
 homepage: https://github.com/karate/drupal-dev
 docs: https://github.com/karate/drupal-dev
-logo: 
+logo: https://avatars.githubusercontent.com/u/1358965
 
 description: "CLI tools for local Drupal development using Docker and tmux."
 


### PR DESCRIPTION
I added my GitHub avatar as an icon for the karate/drupal-dev repo.

I was not able to build and run the site locally, so I haven't tested properly, but it should be ok.