### PR TITLE
Add coder-ddev project entry and remove Vortex recommended flag

### DIFF
--- a/_data/projects/coder-ddev.yml
+++ b/_data/projects/coder-ddev.yml
@@ -1,0 +1,22 @@
+name: coder-ddev
+year_created: 2026
+source: https://github.com/ddev/coder-ddev
+homepage: https://github.com/ddev/coder-ddev
+docs: https://github.com/ddev/coder-ddev#readme
+logo:
+description: "Coder workspace templates for DDEV-based development with Docker-in-Docker support, including a Drupal core development template and a general-purpose template."
+recommended: true
+requires:
+  - docker
+  - ddev
+drupal_versions:
+  - 11
+operation_system:
+  - linux
+category:
+  - cloud
+  - development
+  - docker
+  - workflow
+similar:
+  - ddev

--- a/_data/projects/vortex.yml
+++ b/_data/projects/vortex.yml
@@ -5,7 +5,6 @@ homepage: https://www.vortextemplate.com/
 docs: https://github.com/drevops/vortex#readme
 logo: https://www.vortextemplate.com/img/logo-vortex-dark.svg
 description: "A Drupal project template that ships containerized local environments, automated testing, and CI/CD scaffolding so teams can start fast."
-recommended: true
 requires:
   - cli
   - composer


### PR DESCRIPTION
### Motivation
- Introduce a new `coder-ddev` project entry for DDEV-based Coder workspace templates and update the Vortex metadata to no longer be marked as recommended.

### Description
- Add `_data/projects/coder-ddev.yml` containing metadata (name, year_created, source, homepage, docs, description, requirements, drupal_versions, operation_system, category, and similar).
- Remove the `recommended: true` flag from `_data/projects/vortex.yml` to change its recommendation status.

### Testing
- No automated tests were run for these data-only YAML changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c006683f348326be65952169ca0773)